### PR TITLE
Fix for compatibility with Polly v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Polly.Caching.MemoryCache change log
 
+## 2.0.1
+- Upgrade for compatibility with Polly v6.1.1
+
 ## 2.0.0
 - Provide a single signed package only.
 - Reference Polly v6.0.1.

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 2.0.0
+next-version: 2.0.1

--- a/src/Polly.Caching.Memory.NetStandard13/Polly.Caching.Memory.NetStandard13.csproj
+++ b/src/Polly.Caching.Memory.NetStandard13/Polly.Caching.Memory.NetStandard13.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="6.1.1" />
   </ItemGroup>
   <Import Project="..\Polly.Caching.Memory.Shared\Polly.Caching.Memory.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Polly.Caching.Memory.NetStandard13/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Memory.NetStandard13/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Memory")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 [assembly: CLSCompliant(false)] // Because Microsoft.Extensions.Caching.Memory.MemoryCache, on which Polly.Caching.MemoryCache.NetStandard13 depends, is not CLSCompliant.
 
 [assembly: InternalsVisibleTo("Polly.Caching.Memory.NetStandard13.Specs")]

--- a/src/Polly.Caching.Memory.NetStandard20/Polly.Caching.Memory.NetStandard20.csproj
+++ b/src/Polly.Caching.Memory.NetStandard20/Polly.Caching.Memory.NetStandard20.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.2" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="6.1.1" />
   </ItemGroup>
   <Import Project="..\Polly.Caching.Memory.Shared\Polly.Caching.Memory.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Polly.Caching.Memory.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Memory.NetStandard20/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Memory")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 [assembly: CLSCompliant(false)] // Because Microsoft.Extensions.Caching.Memory.MemoryCache, on which Polly.Caching.MemoryCache.NetStandard13 depends, is not CLSCompliant.
 
 [assembly: InternalsVisibleTo("Polly.Caching.Memory.NetStandard20.Specs")]

--- a/src/Polly.Caching.Memory.Shared/MemoryCacheProvider.cs
+++ b/src/Polly.Caching.Memory.Shared/MemoryCacheProvider.cs
@@ -78,7 +78,7 @@ else
         public Task<object> GetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return TaskHelper.FromResult(Get(key));
+            return Task.FromResult(Get(key));
             // (With C#7.0, a ValueTask<> approach would be preferred, but some of our tfms do not support that.  TO DO: Implement it, with preprocessor if/endif directives, for NetStandard)
         }
 
@@ -96,7 +96,7 @@ else
         {
             cancellationToken.ThrowIfCancellationRequested();
             Put(key, value, ttl);
-            return TaskHelper.EmptyTask;
+            return Task.CompletedTask;
             // (With C#7.0, a ValueTask<> approach would be preferred, but some of our tfms do not support that. TO DO: Implement it, with preprocessor if/endif directives, for NetStandard)
         }
     }

--- a/src/Polly.Caching.Memory.nuspec
+++ b/src/Polly.Caching.Memory.nuspec
@@ -13,6 +13,10 @@
     <tags>Polly Cache Caching Cache-aside</tags>
     <copyright>Copyright © 2018, App vNext</copyright>
     <releaseNotes>
+     2.0.1
+     ---------------------
+     - Upgrade for compatibility with Polly v6.1.1
+
      2.0.0
      ---------------------
      - Provide a single signed package only.
@@ -44,12 +48,12 @@
     <dependencies>
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="6.1.1" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="1.1.2" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.0" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="6.1.1" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="2.0.2" />
       </group>
     </dependencies>

--- a/src/Polly.Caching.Memory.nuspec
+++ b/src/Polly.Caching.Memory.nuspec
@@ -52,7 +52,6 @@
         <dependency id="Microsoft.Extensions.Caching.Memory" version="1.1.2" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="Polly" version="6.1.1" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="2.0.2" />
       </group>


### PR DESCRIPTION
Fixes https://github.com/App-vNext/Polly/issues/539
Also fixes #26 : Remove explicit dependency reference to NetStandard.Library 2.0.0