### PR TITLE
fix: updated Microsoft.Extensions.Caching.Memory to 2.2.0

### DIFF
--- a/src/Polly.Caching.Memory.NetStandard20/Polly.Caching.Memory.NetStandard20.csproj
+++ b/src/Polly.Caching.Memory.NetStandard20/Polly.Caching.Memory.NetStandard20.csproj
@@ -28,7 +28,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Polly" Version="7.0.0" />
   </ItemGroup>
   <Import Project="..\Polly.Caching.Memory.Shared\Polly.Caching.Memory.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Updated Microsoft.Extensions.Caching.Memory to 2.2.0 to fix a known vulnerability. CVE-2018-0786

Issue  #37